### PR TITLE
fix: pin Spring Boot Admin to 4.1.2 to stop InMemoryEventStore OOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,16 @@
 	<version>1.0</version>
 	<name>spring-boot-admin</name>
 	<description>Spring Boot Admin</description>
-	<properties />
+	<properties>
+		<!--
+			Pin Spring Boot Admin to 4.1.2. 4.1.1 (pulled in by dept44 8.0.8) has an InMemoryEventStore
+			memory leak: it detects status changes with a FULL equality check on the instance, so the
+			ever-changing info/details payload mints a new event on every poll, exhausting the heap
+			(codecentric/spring-boot-admin#5476, fixed by #5483). 4.1.2 defaults status-change detection
+			back to STATUS_ONLY. Remove this override once dept44 manages 4.1.2 or newer.
+		-->
+		<spring-boot-admin.version>4.1.2</spring-boot-admin.version>
+	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
dept44 8.0.8 pulls SBA 4.1.1, which detects status changes with a FULL equality check on the instance (PR codecentric/spring-boot-admin#5373). The instance info/details payload changes on every 30s poll, so a new InstanceStatusChangedEvent is minted each poll for every instance, filling the InMemoryEventStore until the heap is exhausted. In production this OOMs and restarts the pod roughly every 15-20 minutes.

SBA 4.1.2 (issue #5476, fix #5483) adds a status-change-detection-strategy and defaults it back to STATUS_ONLY (pre-4.1.1 behaviour), so only real status-code transitions create events. Override the BOM version until dept44 manages 4.1.2 or newer. Spring Boot stays at 4.1.0; build and tests pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
