### PR TITLE
HYDRAN-2675: Drop Spring Boot Admin version pin, use dept44-managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,7 @@
 	<version>1.0</version>
 	<name>spring-boot-admin</name>
 	<description>Spring Boot Admin</description>
-	<properties>
-		<!--
-			Pin Spring Boot Admin to 4.1.2. 4.1.1 (pulled in by dept44 8.0.8) has an InMemoryEventStore
-			memory leak: it detects status changes with a FULL equality check on the instance, so the
-			ever-changing info/details payload mints a new event on every poll, exhausting the heap
-			(codecentric/spring-boot-admin#5476, fixed by #5483). 4.1.2 defaults status-change detection
-			back to STATUS_ONLY. Remove this override once dept44 manages 4.1.2 or newer.
-		-->
-		<spring-boot-admin.version>4.1.2</spring-boot-admin.version>
-	</properties>
+	<properties />
 	<dependencyManagement>
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
Removes the local `spring-boot-admin.version` override so the version is once again managed by dept44.

The pin was added in 025a85d (#137) to escape the `InMemoryEventStore` memory leak in SBA 4.1.1 — status-change detection used a full equality check on the instance, so the ever-changing info/details payload minted a new `InstanceStatusChangedEvent` on every 30s poll and OOM-ed the pod every 15–20 minutes. That commit explicitly scoped the override: *"Remove this override once dept44 manages 4.1.2 or newer."*

`dept44-parent` 8.0.9 (pulled in by #139) now sets `<spring-boot-admin.version>4.1.2</spring-boot-admin.version>` itself, so the condition is met and the override is dead weight.

## What changed

- `pom.xml`: `<properties>` block with the pin + explanatory comment reverted to `<properties />` — identical to the pre-#137 state.

The `dependencyManagement` BOM import is untouched; it predates the pin and already resolved through `${spring-boot-admin.version}`. It now inherits that property from dept44 instead of from this pom, so future parent bumps carry the SBA version along automatically.

## Reviewer notes

- **No version change in practice.** The resolved artifact is still 4.1.2 — verified with `mvn help:evaluate -Dexpression=spring-boot-admin.version` (→ `4.1.2`, inherited) and `mvn dependency:tree -Dincludes=de.codecentric` (→ `spring-boot-admin-starter-server:4.1.2`). The 4.1.1 leak cannot reappear via this change.
- **Risk is a future dept44 bump**, not this PR: if dept44 ever moves back to a version without `status-change-detection-strategy`, we would inherit it silently. That is the tradeoff we accept in exchange for not carrying a stale override.
- `mvn clean verify` passes; JaCoCo coverage checks green.

## Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
